### PR TITLE
ci: reduce Actions spend (drop daily cron, slim PR fan-out, monthly dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     target-branch: "develop"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:
@@ -18,7 +18,7 @@ updates:
     directory: "/"
     target-branch: "develop"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       go-deps:
         patterns:
@@ -35,6 +35,10 @@ updates:
     directory: "/npm"
     target-branch: "develop"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      npm-deps:
+        patterns:
+          - "*"
     commit-message:
       prefix: "fix(deps)"

--- a/.github/workflows/ckb.yml
+++ b/.github/workflows/ckb.yml
@@ -27,8 +27,6 @@ name: CKB
 on:
   pull_request:
     branches: [develop, main, 'feature/**']
-  schedule:
-    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -3,8 +3,6 @@ name: Security Audit
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    branches: [main, develop, 'feature/**']
   schedule:
     # Run weekly on Monday at 6:00 UTC
     - cron: '0 6 * * 1'


### PR DESCRIPTION
## Warum

Actions-Storage/Compute lief dauerhaft auf, obwohl seit Monaten keine manuellen Commits kamen. Ursachen:

- **Täglicher Cron** in `ckb.yml` (`0 3 * * *`) → Reindex jede Nacht
- **Dependabot** (wöchentlich) × **~15 Workflows Fan-out pro PR** → tausende PR-Runs
- Security-Audit lief bei **jedem PR** (8 Sub-Workflows)

## Änderungen

- **ckb.yml**: täglichen `schedule`-Cron entfernt. Reindex läuft weiter manuell via `workflow_dispatch`.
- **security-audit.yml**: `pull_request`-Trigger entfernt. Security läuft jetzt auf push→main/develop + wöchentlichem Cron (Mo 06:00) + manuell.
- **dependabot.yml**: alle Ökosysteme `weekly` → `monthly`; npm-Updates gruppiert (ein PR statt vieler).

## Hinweise

- Keine Branch-Protection aktiv → kein Required-Check wird blockiert.
- Security-Coverage auf PRs entfällt bewusst (kommt weiter auf main + wöchentlich). Bei Bedarf zurücknehmbar.